### PR TITLE
When 0 segments found, launch one scan

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ module.exports = function(Dynamo, Params, Callback) {
         //Get numbers of Segements for this table, in Mega Bytes
         var nbSegments = Math.round(data.Table.TableSizeBytes/1000000);
 
+        if(!nbSegments) nbSegments = 1
+
         //Just to obtain an array of segments
         var segments = []
         for(var i = 0; nbSegments > i; i++) { segments.push(i) }


### PR DESCRIPTION
The describe table is updated every ~ 6hours, by example when we create a new table:

So 0Mb = 0 segment

This fix still add 1 segment in this case.